### PR TITLE
Enrich Epiverse registry metadata for package selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # epiagent
+
+This repository sketches a model context protocol that allows a language-model
+agent to interact with Epiverse Trace R packages through Python.
+
+Key components:
+
+* `src/epiagent/tools/r_wrappers.py` exposes dynamic wrappers that can call any
+  Epiverse Trace function via `rpy2` while handling argument/result
+  serialisation for agents.
+* `src/epiagent/tools/registry.py` maintains a synchronisable catalogue of
+  Epiverse Trace repositories backed by `docs/epiverse_packages.json`, including
+  GitHub-sourced summaries, topical tags and coarse categories to help the
+  agent pick the right package.
+* `docs/tool_manifest.json` supplies structured metadata describing the
+  high-level tools available to an agent.
+* `docs/model_context_protocol.md` summarises the end-to-end workflow for
+  curation, manifest construction and agentic orchestration.
+
+Use the `list_epiverse_packages` tool with `refresh=true` to ensure the registry
+tracks newly published Epiverse Trace repositories before calling
+`call_epiverse_function`. The returned metadata makes it easy to map user
+requests (for example “clean a linelist” versus “estimate Rt”) to the relevant
+Epiverse package prior to execution. Keep the manifest lightweight—link out to
+package READMEs or vignettes rather than embedding every repository's
+documentation in the MCP assets.

--- a/docs/epiverse_packages.json
+++ b/docs/epiverse_packages.json
@@ -1,0 +1,735 @@
+[
+  {
+    "name": ".github",
+    "summary": "",
+    "category": "infrastructure",
+    "topics": [
+      "community-health",
+      "continuous-integration",
+      "defaults",
+      "github-organization",
+      "infrastructure",
+      "quality-assurance",
+      "r-package-automation"
+    ],
+    "homepage": "https://github.com/epiverse-trace/.github"
+  },
+  {
+    "name": "blueprints",
+    "summary": "Software development blueprints for epiverse-trace",
+    "category": "repository",
+    "topics": [
+      "best-practices",
+      "epiverse",
+      "internal-docs",
+      "onboarding",
+      "r-package-development",
+      "standard-operating-procedure",
+      "standards"
+    ],
+    "homepage": "https://github.com/epiverse-trace/blueprints"
+  },
+  {
+    "name": "cfr",
+    "summary": "R package to estimate disease severity and under-reporting in real-time, accounting for reporting delays in epidemic time-series",
+    "category": "r_package",
+    "topics": [
+      "case-fatality-rate",
+      "epidemic-modelling",
+      "epidemiology",
+      "epiverse",
+      "health-outcomes",
+      "outbreak-analysis",
+      "r",
+      "r-package",
+      "sdg-3"
+    ],
+    "homepage": "https://github.com/epiverse-trace/cfr"
+  },
+  {
+    "name": "cleanepi",
+    "summary": "R package to clean and standardize epidemiological data",
+    "category": "r_package",
+    "topics": [
+      "data-cleaning",
+      "epidemiology",
+      "epiverse",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/cleanepi"
+  },
+  {
+    "name": "climateR0",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/climateR0"
+  },
+  {
+    "name": "ColOpenData",
+    "summary": "ColOpenData is a package that acquires and wrangles Colombian socioeconomic, geospatial and climate data",
+    "category": "r_package",
+    "topics": [
+      "climate",
+      "colombia",
+      "data-package",
+      "demographics",
+      "maps",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/ColOpenData"
+  },
+  {
+    "name": "epi-training-kit",
+    "summary": "An e-learning strategy for training on analysis, modelling and response to outbreaks and epidemics in Latin-America and the Caribbean",
+    "category": "r_package",
+    "topics": [
+      "data-science",
+      "e-learning",
+      "epidemics",
+      "training"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epi-training-kit"
+  },
+  {
+    "name": "epichains",
+    "summary": "Methods for simulating and analysing the sizes and lengths of infectious disease transmission chains from branching process models",
+    "category": "r_package",
+    "topics": [
+      "branching-processes",
+      "epidemic-dynamics",
+      "epidemic-modelling",
+      "epidemic-simulations",
+      "epidemiology",
+      "epidemiology-models",
+      "outbreak-simulator",
+      "r-package",
+      "r-stats",
+      "transmission-chain",
+      "transmission-chain-reconstruction"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epichains"
+  },
+  {
+    "name": "epiCo",
+    "summary": "R package for statistical and spatiotemporal modeling of epidemiological data for vector-borne diseases in Colombia",
+    "category": "r_package",
+    "topics": [
+      "colombia",
+      "decision-support",
+      "demographics",
+      "epiverse",
+      "outbreak-analysis",
+      "r",
+      "r-package",
+      "sdg-3",
+      "spatio-temporal-analysis",
+      "vector-borne-diseases"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epiCo"
+  },
+  {
+    "name": "epidemics",
+    "summary": "A library of published compartmental epidemic models, and classes to represent demographic structure, non-pharmaceutical interventions, and vaccination regimes, to compose epidemic scenarios.",
+    "category": "r_package",
+    "topics": [
+      "decision-support",
+      "epidemic-modelling",
+      "epidemic-simulations",
+      "epidemiology",
+      "epiverse",
+      "infectious-disease-dynamics",
+      "model-library",
+      "non-pharmaceutical-interventions",
+      "r",
+      "r-package",
+      "rcpp",
+      "rcppeigen",
+      "scenario-analysis",
+      "vaccination"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epidemics"
+  },
+  {
+    "name": "epimodelac",
+    "summary": "Training materials for the epimodelac workshop",
+    "category": "r_package",
+    "topics": [
+      "carpentries-workbench",
+      "r",
+      "rstats"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epimodelac"
+  },
+  {
+    "name": "epimodelac-en",
+    "summary": "Training materials for the epimodelac workshop",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/epimodelac-en"
+  },
+  {
+    "name": "epinetwork",
+    "summary": "Modelling transmission on real-world social networks",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/epinetwork"
+  },
+  {
+    "name": "epiparameter",
+    "summary": "R package with classes and helper functions for working with epidemiological parameters and access to a library of epidemiological parameters for infectious diseases",
+    "category": "r_package",
+    "topics": [
+      "data-access",
+      "data-package",
+      "epidemiology",
+      "epiverse",
+      "probability-distribution",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epiparameter"
+  },
+  {
+    "name": "epiparameterDashboard",
+    "summary": "Explore the database of epidemiological parameters provided by the {epiparameterDB} package",
+    "category": "application",
+    "homepage": "https://github.com/epiverse-trace/epiparameterDashboard"
+  },
+  {
+    "name": "epiparameterDB",
+    "summary": "Database of epidemiological parameters",
+    "category": "r_package",
+    "topics": [
+      "data-package",
+      "epidemiology",
+      "epiverse",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epiparameterDB"
+  },
+  {
+    "name": "epishiny",
+    "summary": "[FORK] Tools for interactive visualisation of epidemiological linelist data",
+    "category": "application",
+    "homepage": "https://github.com/epiverse-trace/epishiny"
+  },
+  {
+    "name": "epishowcase",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/epishowcase"
+  },
+  {
+    "name": "episoap",
+    "summary": "[Not published - under active development] A Store of Outbreak Analytics Pipelines Provided as Rmarkdown Report Templates",
+    "category": "r_package",
+    "topics": [
+      "automated-report",
+      "decision-support",
+      "epidemiology",
+      "epiverse",
+      "literate-programming",
+      "outbreak-analysis",
+      "pipelines",
+      "r",
+      "r-package",
+      "rmarkdown-templates"
+    ],
+    "homepage": "https://github.com/epiverse-trace/episoap"
+  },
+  {
+    "name": "epitkit",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/epitkit"
+  },
+  {
+    "name": "EpiTKit-EN",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/EpiTKit-EN"
+  },
+  {
+    "name": "EpiTKit-FR",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/EpiTKit-FR"
+  },
+  {
+    "name": "epiverse",
+    "summary": "Meta-package for the Epiverse-TRACE R packages",
+    "category": "r_package",
+    "topics": [
+      "epiverse",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epiverse"
+  },
+  {
+    "name": "epiverse-trace.github.io",
+    "summary": "Technical blog of the Epiverse-TRACE project, where we share opinions and investigations in R package development, or scientific software development more generally",
+    "category": "r_package",
+    "topics": [
+      "blog",
+      "epiverse",
+      "quarto-website"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epiverse-trace.github.io"
+  },
+  {
+    "name": "epiverse-trace.r-universe.dev",
+    "summary": "R-universe for the epiverse-trace GitHub organisation",
+    "category": "repository",
+    "topics": [
+      "automation",
+      "continuous-deployment",
+      "epiverse",
+      "infrastructure"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epiverse-trace.r-universe.dev"
+  },
+  {
+    "name": "epiverse_demos",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/epiverse_demos"
+  },
+  {
+    "name": "epiversedashboard",
+    "summary": "Epiverse-TRACE activity dashboard",
+    "category": "application",
+    "topics": [
+      "infrastructure"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epiversedashboard"
+  },
+  {
+    "name": "epiverselearner",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/epiverselearner"
+  },
+  {
+    "name": "epiversetheme",
+    "summary": "",
+    "category": "r_package",
+    "topics": [
+      "community-health",
+      "epiverse",
+      "infrastructure",
+      "organisation-tool",
+      "pkgdown-template",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/epiversetheme"
+  },
+  {
+    "name": "etdashboard",
+    "summary": "Developer dashboard for a universe overview of Epiverse-TRACE packages",
+    "category": "application",
+    "homepage": "https://github.com/epiverse-trace/etdashboard"
+  },
+  {
+    "name": "etstats",
+    "summary": "",
+    "category": "r_package",
+    "topics": [
+      "organisation-tool",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/etstats"
+  },
+  {
+    "name": "finalsize",
+    "summary": "R package to calculate the final size of an SIR epidemic in populations with heterogeneity in social contacts and disease susceptibility",
+    "category": "r_package",
+    "topics": [
+      "epidemic-modelling",
+      "epidemiology",
+      "epiverse",
+      "outbreak-analysis",
+      "r",
+      "r-package",
+      "rcpp",
+      "sdg-3"
+    ],
+    "homepage": "https://github.com/epiverse-trace/finalsize"
+  },
+  {
+    "name": "gam-summit",
+    "summary": "",
+    "category": "documentation",
+    "homepage": "https://github.com/epiverse-trace/gam-summit"
+  },
+  {
+    "name": "git-rstudio-basics",
+    "summary": "Version Control with Git using Rstudio",
+    "category": "r_package",
+    "topics": [
+      "alpha-stage",
+      "carpentries-workbench",
+      "git",
+      "github",
+      "novice",
+      "rstudio",
+      "version-control"
+    ],
+    "homepage": "https://github.com/epiverse-trace/git-rstudio-basics"
+  },
+  {
+    "name": "hex-stickers",
+    "summary": "",
+    "category": "infrastructure",
+    "topics": [
+      "epiverse",
+      "logos"
+    ],
+    "homepage": "https://github.com/epiverse-trace/hex-stickers"
+  },
+  {
+    "name": "howto",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/howto"
+  },
+  {
+    "name": "iraca",
+    "summary": "Agent-Based model simulation of mosquito-human interaction in the Colombian and LAC setting",
+    "category": "r_package",
+    "topics": [
+      "agent-based-modeling",
+      "r",
+      "r-package",
+      "rcpp",
+      "vector-borne-diseases"
+    ],
+    "homepage": "https://github.com/epiverse-trace/iraca"
+  },
+  {
+    "name": "linelist",
+    "summary": "R package for handling linelist data",
+    "category": "r_package",
+    "topics": [
+      "data",
+      "data-structures",
+      "epidemiology",
+      "epiverse",
+      "outbreaks",
+      "r",
+      "r-package",
+      "sdg-3",
+      "structured-data"
+    ],
+    "homepage": "https://github.com/epiverse-trace/linelist"
+  },
+  {
+    "name": "llm-guidance",
+    "summary": "Exploring use of LLMs to guide users to relevant packages/documentation",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/llm-guidance"
+  },
+  {
+    "name": "numberize",
+    "summary": "Convert words to numbers in English, French and Spanish",
+    "category": "r_package",
+    "topics": [
+      "r-package",
+      "r-programming"
+    ],
+    "homepage": "https://github.com/epiverse-trace/numberize"
+  },
+  {
+    "name": "packagetemplate",
+    "summary": "Template of an R package with standard Epiverse-TRACE automation",
+    "category": "r_package",
+    "topics": [
+      "github-template",
+      "r",
+      "r-package",
+      "template-repository"
+    ],
+    "homepage": "https://github.com/epiverse-trace/packagetemplate"
+  },
+  {
+    "name": "personas",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/personas"
+  },
+  {
+    "name": "quickfit",
+    "summary": "[SUSPENDED] Toolbox of model fitting helper functions",
+    "category": "r_package",
+    "topics": [
+      "distributions",
+      "likelihood",
+      "mle",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/quickfit"
+  },
+  {
+    "name": "readepi",
+    "summary": "An R package for importing epi data into R.",
+    "category": "r_package",
+    "topics": [
+      "data-import",
+      "epidemiology",
+      "epiverse",
+      "health-information-systems",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/readepi"
+  },
+  {
+    "name": "research-compendium",
+    "summary": "",
+    "category": "r_package",
+    "topics": [
+      "carpentries-workbench",
+      "english-language",
+      "pre-alpha",
+      "reproducible-research",
+      "research-compendium",
+      "rstats"
+    ],
+    "homepage": "https://github.com/epiverse-trace/research-compendium"
+  },
+  {
+    "name": "rmdscaffold",
+    "summary": "[Not published - under active development]",
+    "category": "r_package",
+    "topics": [
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/rmdscaffold"
+  },
+  {
+    "name": "safeframe",
+    "summary": "Tagging, validating, and safeguarding data to help harden data pipelines.",
+    "category": "r_package",
+    "topics": [
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/safeframe"
+  },
+  {
+    "name": "sandpaper",
+    "summary": "[FORK] User Interface for The Carpentries Workbench",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/sandpaper"
+  },
+  {
+    "name": "scenarios",
+    "summary": "[SUSPENDED]: R package to compare epidemic scenario model outcomes.",
+    "category": "r_package",
+    "topics": [
+      "epidemic-modelling",
+      "epidemiology",
+      "epiverse",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/scenarios"
+  },
+  {
+    "name": "serofoi",
+    "summary": "Estimates the Force-of-Infection of a given pathogen from population based sero-prevalence studies",
+    "category": "r_package",
+    "topics": [
+      "antibodies",
+      "bayesian-methods",
+      "epidemiology",
+      "epiverse",
+      "r",
+      "r-package",
+      "serological-surveys",
+      "stan-language"
+    ],
+    "homepage": "https://github.com/epiverse-trace/serofoi"
+  },
+  {
+    "name": "Severity_methods_assessment",
+    "summary": "Assessment of severity estimation methods during an infectious disease outbreak",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/Severity_methods_assessment"
+  },
+  {
+    "name": "shinyapps-tracelac",
+    "summary": "",
+    "category": "application",
+    "homepage": "https://github.com/epiverse-trace/shinyapps-tracelac"
+  },
+  {
+    "name": "showcasedata",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/showcasedata"
+  },
+  {
+    "name": "simulist",
+    "summary": "An R package for simulating line lists",
+    "category": "r_package",
+    "topics": [
+      "epidemiology",
+      "epiverse",
+      "linelist",
+      "outbreaks",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/simulist"
+  },
+  {
+    "name": "sivirep",
+    "summary": "Data Wrangling and Automated Reports from 'SIVIGILA' source",
+    "category": "r_package",
+    "topics": [
+      "colombia",
+      "epidemiological-surveillance",
+      "epiverse",
+      "public-health",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/sivirep"
+  },
+  {
+    "name": "superspreading",
+    "summary": "Estimation of individual-level variation in transmission",
+    "category": "r_package",
+    "topics": [
+      "disease-transmission",
+      "epidemiology",
+      "epiverse",
+      "r",
+      "r-package"
+    ],
+    "homepage": "https://github.com/epiverse-trace/superspreading"
+  },
+  {
+    "name": "tracetheme",
+    "summary": "ggplot theme and scale for Epiverse-TRACE plots",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/tracetheme"
+  },
+  {
+    "name": "translation-epitkit",
+    "summary": "",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/translation-epitkit"
+  },
+  {
+    "name": "tutorials",
+    "summary": "",
+    "category": "r_package",
+    "topics": [
+      "carpentries-workbench",
+      "english-language",
+      "epidemic-modelling",
+      "outbreak-analysis",
+      "pre-alpha",
+      "rstats"
+    ],
+    "homepage": "https://github.com/epiverse-trace/tutorials"
+  },
+  {
+    "name": "tutorials-early",
+    "summary": "Tutorials to learn reading, cleaning and validating case data, and converting line list data to incidence for visualizing epidemic curves.",
+    "category": "r_package",
+    "topics": [
+      "carpentries-workbench",
+      "data-cleaning",
+      "data-validation",
+      "data-visualization",
+      "english-language",
+      "epiverse",
+      "exploratory-data-analysis",
+      "outbreak-analysis",
+      "rstats"
+    ],
+    "homepage": "https://github.com/epiverse-trace/tutorials-early"
+  },
+  {
+    "name": "tutorials-early-fr",
+    "summary": "Tutorials to learn reading, cleaning and validating case data, and converting line list data to incidence for visualizing epidemic curves.",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/tutorials-early-fr"
+  },
+  {
+    "name": "tutorials-late",
+    "summary": "Tutorials to learn accessing and analyzing social contact matrices, scenario modelling to simulate disease spread and investigate interventions, and modelling disease burden.",
+    "category": "r_package",
+    "topics": [
+      "burden-of-disease",
+      "carpentries-workbench",
+      "contact-matrices",
+      "contact-matrix",
+      "epiverse",
+      "infectious-disease-dynamics",
+      "non-pharmaceutical-interventions",
+      "outbreak-analysis",
+      "rstats",
+      "scenario-modelling",
+      "vaccination"
+    ],
+    "homepage": "https://github.com/epiverse-trace/tutorials-late"
+  },
+  {
+    "name": "tutorials-middle",
+    "summary": "Tutorials to learn real-time analysis that includes accessing epidemiological delays, estimating transmission metrics, forecasting, and severity from aggregated incidence data, superspreading from line list and contact data, and simulating transmission chains.",
+    "category": "r_package",
+    "topics": [
+      "carpentries-workbench",
+      "english-language",
+      "epiverse",
+      "forecasting",
+      "outbreak-analysis",
+      "outbreak-severity",
+      "real-time-analysis",
+      "reproduction-number",
+      "rstats",
+      "superspreading-events",
+      "transmission-chain"
+    ],
+    "homepage": "https://github.com/epiverse-trace/tutorials-middle"
+  },
+  {
+    "name": "tutorials-middle-es",
+    "summary": "",
+    "category": "training",
+    "homepage": "https://github.com/epiverse-trace/tutorials-middle-es"
+  },
+  {
+    "name": "tutorials-middle-fr",
+    "summary": "Tutorials to learn real-time analysis that includes accessing epidemiological delays, estimating transmission metrics, forecasting, and severity from aggregated incidence data, superspreading from line list and contact data, and simulating transmission chains.",
+    "category": "r_package",
+    "homepage": "https://github.com/epiverse-trace/tutorials-middle-fr"
+  },
+  {
+    "name": "vaccineff",
+    "summary": "R package with tools for estimating vaccine effectiveness and vaccine related metrics",
+    "category": "r_package",
+    "topics": [
+      "epidemiology",
+      "epiverse",
+      "r",
+      "r-package",
+      "vaccine-effectiveness"
+    ],
+    "homepage": "https://github.com/epiverse-trace/vaccineff"
+  },
+  {
+    "name": "varnish",
+    "summary": "Epiverse-TRACE fork of the Carpentries' workbench varnish package",
+    "category": "repository",
+    "homepage": "https://github.com/epiverse-trace/varnish"
+  }
+]

--- a/docs/model_context_protocol.md
+++ b/docs/model_context_protocol.md
@@ -1,0 +1,88 @@
+# Model Context Protocol for Epiverse Agents
+
+This document outlines how to expose Epiverse R functionality to a language-model
+agent using a three-phase workflow:
+
+1. **Tool curation and wrapping** – dynamically expose Epiverse Trace
+   functionality to Python via `rpy2`.
+2. **Tool manifest construction** – describe each wrapper using JSON schemas so
+   the agent can understand their capabilities and argument requirements.
+3. **Agentic workflow orchestration** – wire the tools into a Reason-Act loop so
+   the agent can plan multi-step epidemiological analyses.
+
+## Phase 1 – Tool curation and wrapping
+
+* Use the Epiverse Trace catalogue maintained in
+  [`docs/epiverse_packages.json`](epiverse_packages.json) to understand which
+  repositories are currently available. Each entry now ships with the GitHub
+  summary, topical tags and a coarse category (for example `r_package`,
+  `training`, or `application`) so the agent can quickly shortlist suitable
+  tooling. When refreshing from GitHub the registry will merge any new topics or
+  descriptions into the local cache.
+* Rather than building bespoke wrappers for each package, expose a generic
+  entry point (see [`src/epiagent/tools/r_wrappers.py`](../src/epiagent/tools/r_wrappers.py))
+  that can import any Epiverse Trace package, convert Python arguments into R
+  objects, and return structured payloads for the agent. The exported
+  `call_epiverse_function` helper supports positional and keyword arguments plus
+  automatic pandas/R data-frame conversion.
+* Retain defensive error handling so agents can recover gracefully and consider
+  persisting artefacts (plots, RDS files) when needed for downstream tools.
+
+## Phase 2 – Tool manifest
+
+* Provide manifest entries for the generic wrappers (`list_epiverse_packages`
+  and `call_epiverse_function`), including guidance on which packages exist and
+  how to refresh the registry from GitHub. Surface the curated metadata in the
+  manifest description so the model knows that `list_epiverse_packages`
+  returns summaries, categories and topical tags that it can use to reason over
+  which package to call next.
+* The [`tool_manifest.json`](tool_manifest.json) file can be loaded into an
+  agent framework (e.g. LangChain) to register the tools.
+* Rich descriptions improve tool selection reliability; include domain context,
+  expected data formats and defaults.
+* **Do not attempt to inline every package manual.** The manifest should remain
+  lightweight and focus on describing the wrapper surface. Package-specific
+  context can be surfaced on demand by pointing the agent to upstream
+  documentation URLs or pre-curated notes, while the registry keeps the full
+  list of callable packages discoverable.
+
+## Phase 3 – Agentic workflow
+
+1. Accept user instructions and supporting data.
+2. Let the agent deliberate over the manifest to select the next tool.
+3. Execute the corresponding Python wrapper and capture the structured result.
+4. Feed observations back to the agent so it can iterate, plan further actions
+   and compose a final report with figures or tables.
+
+### Operational guidance
+
+* **Sandboxing** – package the environment in Docker with pinned R/epiverse
+  dependencies.
+* **Data privacy** – ensure PHI never leaves secure infrastructure.
+* **Observability** – log tool invocations, inputs and outputs for auditing and
+  debugging.
+* **Prompting** – prime the agent with epidemiological expertise and highlight
+  how to interpret tool responses.
+* **Registry maintenance** – periodically run the `list_epiverse_packages`
+  tool with `refresh=true` to pull new repositories from GitHub so that
+  `call_epiverse_function` can access the latest Epiverse Trace utilities.
+* **Documentation strategy** – reference upstream READMEs, vignettes or
+  curated cheat-sheets instead of embedding the entire package documentation in
+  the MCP artefacts. Summaries or links are sufficient for the agent to choose
+  tools, and keep the protocol assets maintainable.
+* **Package selection** – encourage the agent (via system prompt examples or
+  additional documentation) to first call `list_epiverse_packages` and inspect
+  the returned metadata before invoking a specific Epiverse function. The
+  combination of package summaries, topical tags and categories provides enough
+  signal for the model to map user requests (e.g. “estimate Rt from daily
+  incidence”) to the correct package (such as `EpiEstim` or `incidence2`).
+
+#### Example: choosing the right package
+
+1. The agent receives: “Clean this linelist and build a quick contact chain
+   view.”
+2. It first calls `list_epiverse_packages` and filters for entries with the
+   `r_package` category whose summaries mention “clean” or “contact”.
+3. The metadata highlights `cleanepi` for linelist hygiene and `epichains` for
+   transmission exploration, prompting a plan to run `call_epiverse_function`
+   twice—once per package—before synthesising the response.

--- a/docs/tool_manifest.json
+++ b/docs/tool_manifest.json
@@ -1,0 +1,49 @@
+[
+  {
+    "name": "list_epiverse_packages",
+    "description": "Return the cached catalogue of Epiverse Trace repositories (including summaries, topical tags, and coarse categories) that the agent can call into. Refresh the cache to pull the latest packages and metadata from GitHub.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "refresh": {
+          "type": "boolean",
+          "description": "Set to true to query GitHub for the newest package list before returning results.",
+          "default": false
+        }
+      }
+    }
+  },
+  {
+    "name": "call_epiverse_function",
+    "description": "Invoke any function from an Epiverse Trace R package via rpy2. Supports automatic conversion between pandas objects and R data frames. Use the package summaries returned by list_epiverse_packages to choose an appropriate target before calling.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "package": {
+          "type": "string",
+          "description": "Name of the Epiverse Trace R package (e.g., incidence2, linelist, epiparameter)."
+        },
+        "function": {
+          "type": "string",
+          "description": "Function within the package to execute."
+        },
+        "args": {
+          "type": "array",
+          "description": "Optional ordered arguments passed positionally to the R function.",
+          "items": {}
+        },
+        "kwargs": {
+          "type": "object",
+          "description": "Optional named arguments passed to the R function.",
+          "additionalProperties": {}
+        },
+        "auto_convert": {
+          "type": "boolean",
+          "description": "If true (default), automatically convert pandas and Python primitives to their R equivalents and back.",
+          "default": true
+        }
+      },
+      "required": ["package", "function"]
+    }
+  }
+]

--- a/src/epiagent/__init__.py
+++ b/src/epiagent/__init__.py
@@ -1,0 +1,13 @@
+"""Top-level package for the epiagent project."""
+
+from .tools.r_wrappers import (
+    ToolResult,
+    call_epiverse_function,
+    list_epiverse_packages,
+)
+
+__all__ = [
+    "ToolResult",
+    "call_epiverse_function",
+    "list_epiverse_packages",
+]

--- a/src/epiagent/tools/r_wrappers.py
+++ b/src/epiagent/tools/r_wrappers.py
@@ -1,0 +1,142 @@
+"""Dynamic wrappers around Epiverse Trace R packages for agent tooling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
+
+import pandas as pd
+
+from .registry import get_registry
+
+try:  # pragma: no cover - optional dependency guard
+    import rpy2.robjects as ro
+    from rpy2.robjects import default_converter
+    from rpy2.robjects.conversion import localconverter
+    from rpy2.robjects.packages import importr
+    from rpy2.robjects import pandas2ri
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "rpy2 is required to use the Epiverse wrappers. Install it via pip "
+        "and ensure that R is available in your environment."
+    ) from exc
+
+pandas2ri.activate()
+
+
+@dataclass
+class ToolResult:
+    """Structured response returned to the calling agent."""
+
+    status: str
+    data: Optional[Any] = None
+    message: Optional[str] = None
+    artifact_path: Optional[Path] = None
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"status": self.status}
+        if self.message:
+            payload["message"] = self.message
+        if self.data is not None:
+            payload["data"] = _serialise_data(self.data)
+        if self.artifact_path is not None:
+            payload["artifact_path"] = str(self.artifact_path)
+        return payload
+
+
+def list_epiverse_packages(refresh: bool = False) -> ToolResult:
+    """Return the known Epiverse Trace repositories."""
+
+    registry = get_registry()
+    if refresh:
+        try:
+            packages = registry.refresh_from_github()
+        except Exception as err:  # pragma: no cover - network failure handling
+            return ToolResult(status="error", message=str(err))
+    else:
+        packages = registry.sorted_packages
+    return ToolResult(
+        status="success",
+        data={"packages": [package.to_dict() for package in packages]},
+    )
+
+
+def call_epiverse_function(
+    package: str,
+    function: str,
+    args: Optional[Sequence[Any]] = None,
+    kwargs: Optional[Mapping[str, Any]] = None,
+    auto_convert: bool = True,
+) -> ToolResult:
+    """Invoke an arbitrary function from an Epiverse Trace R package."""
+
+    registry = get_registry()
+    package_known = registry.has_package(package)
+
+    try:
+        module = _import_package(package)
+    except Exception as err:  # pragma: no cover - R import failure guard
+        message = f"Failed to import R package '{package}': {err}"
+        return ToolResult(status="error", message=message)
+
+    if not hasattr(module, function):
+        message = f"Package '{package}' does not expose a callable named '{function}'"
+        return ToolResult(status="error", message=message)
+
+    r_callable = getattr(module, function)
+    positional_args = list(args or [])
+    keyword_args: MutableMapping[str, Any] = dict(kwargs or {})
+
+    try:
+        if auto_convert:
+            with localconverter(default_converter + pandas2ri.converter):
+                r_args = [ro.conversion.py2rpy(arg) for arg in positional_args]
+                r_kwargs = {key: ro.conversion.py2rpy(val) for key, val in keyword_args.items()}
+            result = r_callable(*r_args, **r_kwargs)
+            with localconverter(default_converter + pandas2ri.converter):
+                converted = ro.conversion.rpy2py(result)
+        else:
+            converted = r_callable(*positional_args, **keyword_args)
+    except Exception as err:  # pragma: no cover - runtime safety
+        return ToolResult(status="error", message=str(err))
+
+    note: Optional[str] = None
+    if not package_known:
+        note = (
+            "Executed function successfully but the package was not present in the local registry. "
+            "Consider refreshing the package list."
+        )
+
+    return ToolResult(status="success", data=converted, message=note)
+
+
+@lru_cache(maxsize=None)
+def _import_package(name: str):
+    """Import an R package through :func:`rpy2.robjects.packages.importr`."""
+
+    return importr(name)
+
+
+def _serialise_data(data: Any) -> Any:
+    if isinstance(data, pd.DataFrame):
+        return {"type": "dataframe", "records": data.to_dict(orient="records")}
+    if isinstance(data, pd.Series):
+        return {"type": "series", "values": data.to_dict()}
+    if isinstance(data, (list, dict, str, int, float, bool)) or data is None:
+        return data
+    if isinstance(data, Path):
+        return str(data)
+    try:
+        return json.loads(json.dumps(data, default=str))
+    except Exception:  # pragma: no cover - fallback serialisation
+        return repr(data)
+
+
+__all__ = [
+    "ToolResult",
+    "list_epiverse_packages",
+    "call_epiverse_function",
+]

--- a/src/epiagent/tools/registry.py
+++ b/src/epiagent/tools/registry.py
@@ -1,0 +1,163 @@
+"""Utility helpers for discovering Epiverse Trace packages."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+import urllib.request
+
+__all__ = ["EpiverseRegistry", "get_registry", "EpiversePackage"]
+
+ORG = "epiverse-trace"
+DEFAULT_REGISTRY_PATH = Path(__file__).resolve().parents[2] / "docs" / "epiverse_packages.json"
+
+
+@dataclass
+class EpiversePackage:
+    """Represents a single Epiverse Trace repository with optional metadata."""
+
+    name: str
+    summary: str = ""
+    category: str = "unknown"
+    homepage: Optional[str] = None
+    topics: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "name": self.name,
+            "category": self.category,
+        }
+        if self.summary:
+            payload["summary"] = self.summary
+        if self.homepage:
+            payload["homepage"] = self.homepage
+        if self.topics:
+            payload["topics"] = sorted(set(self.topics))
+        return payload
+
+    def merge(self, *, summary: Optional[str] = None, topics: Optional[Iterable[str]] = None, homepage: Optional[str] = None) -> "EpiversePackage":
+        if summary and not self.summary:
+            self.summary = summary.strip()
+        if topics:
+            merged = set(self.topics)
+            merged.update(topic for topic in topics if topic)
+            self.topics = sorted(merged)
+        if homepage and not self.homepage:
+            self.homepage = homepage
+        return self
+
+
+@dataclass
+class EpiverseRegistry:
+    """In-memory catalogue of Epiverse Trace repositories."""
+
+    packages: Dict[str, EpiversePackage] = field(default_factory=dict)
+    source: Optional[Path] = None
+
+    @classmethod
+    def load(cls, path: Path = DEFAULT_REGISTRY_PATH) -> "EpiverseRegistry":
+        packages: Dict[str, EpiversePackage] = {}
+        if path.exists():
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            for entry in raw:
+                if isinstance(entry, str):
+                    package = EpiversePackage(name=entry)
+                else:
+                    package = EpiversePackage(
+                        name=entry.get("name"),
+                        summary=entry.get("summary", ""),
+                        category=entry.get("category", "unknown"),
+                        homepage=entry.get("homepage"),
+                        topics=list(entry.get("topics", [])),
+                    )
+                packages[package.name] = package
+        return cls(packages=packages, source=path)
+
+    def save(self, path: Optional[Path] = None) -> None:
+        target = path or self.source
+        if target is None:
+            raise ValueError("No target path supplied for saving the registry")
+        serialised = [pkg.to_dict() for pkg in self.sorted_packages]
+        target.write_text(json.dumps(serialised, indent=2) + "\n", encoding="utf-8")
+
+    def refresh_from_github(self, *, per_page: int = 100) -> List[EpiversePackage]:
+        """Refresh the package list using the GitHub API."""
+
+        url = f"https://api.github.com/orgs/{ORG}/repos?per_page={per_page}"
+        repos = self._fetch_repo_page(url)
+        next_url = repos.next_url
+        all_repos = list(repos.items)
+        while next_url:
+            repos = self._fetch_repo_page(next_url)
+            all_repos.extend(repos.items)
+            next_url = repos.next_url
+        refreshed: Dict[str, EpiversePackage] = {}
+        for repo in all_repos:
+            if repo.get("archived"):
+                continue
+            name = repo["name"]
+            package = self.packages.get(name, EpiversePackage(name=name))
+            package.category = package.category or "unknown"
+            package.merge(
+                summary=repo.get("description"),
+                topics=repo.get("topics"),
+                homepage=repo.get("html_url"),
+            )
+            refreshed[name] = package
+        self.packages = refreshed
+        if self.source:
+            self.save(self.source)
+        return self.sorted_packages
+
+    @property
+    def sorted_packages(self) -> List[EpiversePackage]:
+        return [self.packages[key] for key in sorted(self.packages)]
+
+    def _fetch_repo_page(self, url: str) -> "_RepoPage":
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "epiagent-registry",
+            },
+        )
+        with urllib.request.urlopen(request) as response:  # nosec - controlled URL
+            items = json.load(response)
+            next_url: Optional[str] = None
+            link_header = response.headers.get("Link")
+            if link_header and "rel=\"next\"" in link_header:
+                for part in link_header.split(","):
+                    if "rel=\"next\"" in part:
+                        next_url = part[part.find("<") + 1 : part.find(">")]  # noqa: E203
+                        break
+        return _RepoPage(items=items, next_url=next_url)
+
+    def has_package(self, name: str) -> bool:
+        return name in self.packages
+
+    def ensure_packages(self, packages: Iterable[str]) -> List[str]:
+        """Return the subset of *packages* that exist in the registry."""
+
+        return sorted(set(packages).intersection(self.packages))
+
+    def describe(self, name: str) -> Optional[Dict[str, object]]:
+        package = self.packages.get(name)
+        return package.to_dict() if package else None
+
+
+@dataclass
+class _RepoPage:
+    items: List[dict]
+    next_url: Optional[str]
+
+
+_registry: Optional[EpiverseRegistry] = None
+
+
+def get_registry() -> EpiverseRegistry:
+    global _registry
+    if _registry is None:
+        _registry = EpiverseRegistry.load()
+    return _registry


### PR DESCRIPTION
## Summary
- enrich the Epiverse registry with structured package metadata (summaries, categories, topics, and homepages) sourced from GitHub
- expose the richer metadata through `list_epiverse_packages` and refresh logic so agents can shortlist appropriate tools before executing functions
- update the MCP guide, tool manifest, and README with guidance and examples showing how models should leverage the metadata when choosing packages

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e690a67bc0832aac75a8271be2651d